### PR TITLE
fix: remove eslint-plugin-standard

### DIFF
--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "@fbi-js/eslint-config": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
-    "eslint-config-standard-with-typescript": "^19.0.1",
-    "eslint-plugin-standard": "^5.0.0"
+    "eslint-config-standard-with-typescript": "^19.0.1"
   },
   "peerDependencies": {
     "eslint": ">=7.17.0",


### PR DESCRIPTION
eslint-plugin-standard package has been deprecated

issues: https://github.com/standard/standard/issues/1316