### PR TITLE
feat: optimize css-loader options

### DIFF
--- a/packages/webpack-config-base/package.json
+++ b/packages/webpack-config-base/package.json
@@ -29,6 +29,7 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-typescript": "^7.12.7",
+    "@opd/css-modules-typings-loader": "^1.0.5",
     "babel-loader": "^8.2.2",
     "babel-plugin-import": "^1.13.3",
     "clean-webpack-plugin": "^3.0.0",

--- a/packages/webpack-config-base/src/index.ts
+++ b/packages/webpack-config-base/src/index.ts
@@ -35,37 +35,37 @@ export default ({
     options.babel?.presets.push('@babel/preset-typescript')
   }
 
-  const baseCssLoaders = isDev
-    ? [
-        'style-loader',
-        {
-          loader: 'css-loader',
-          options: { sourceMap: true, importLoaders: 1 }
-        },
-        {
-          loader: 'postcss-loader',
-          options: options.postcss
-        }
-      ]
-    : [
-        {
-          loader: MiniCssExtractPlugin.loader,
-          options: {
-            publicPath: options.paths.cssExtractPublicPath
-          }
-        },
-        {
-          loader: 'css-loader',
-          options: {
-            importLoaders: 2,
-            sourceMap: false
-          }
-        },
-        {
-          loader: 'postcss-loader',
-          options: options.postcss
-        }
-      ]
+  const cssLoaderOptions = {
+    sourceMap: true,
+    importLoaders: 2,
+    modules: {
+      localIdentName: isDev ? '[path][name]__[local]' : '[hash:base64]',
+      exportLocalsConvention: 'camelCaseOnly',
+      auto: true
+    }
+  }
+
+  const baseCssLoaders: any[] = [
+    {
+      loader: 'css-loader',
+      options: cssLoaderOptions
+    },
+    {
+      loader: 'postcss-loader',
+      options: options.postcss
+    }
+  ]
+
+  if (isDev) {
+    baseCssLoaders.unshift('style-loader', '@opd/css-modules-typings-loader')
+  } else {
+    baseCssLoaders.unshift({
+      loader: MiniCssExtractPlugin.loader,
+      options: {
+        publicPath: options.paths.cssExtractPublicPath
+      }
+    })
+  }
 
   const config = {
     mode: getEnvMode(),


### PR DESCRIPTION
- optimize css modules config
  * always export camel case local css class name
  * use readable css modules scoped class name in development mode
- add `@opd/css-modules-typings-loader` to generate css modules type defintions